### PR TITLE
Fix relative asset paths

### DIFF
--- a/dist/vite.config.js
+++ b/dist/vite.config.js
@@ -3,6 +3,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+        base: './',
         define: {
             'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
             'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)

--- a/index.html
+++ b/index.html
@@ -10,13 +10,13 @@
     <title>Tile Merge Saga</title>
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
     <style>
+      @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
       body {
         font-family: 'Inter', sans-serif;
         background-color: #1f2937; /* bg-slate-800 */
         color: #f3f4f6; /* text-slate-100 */
       }
       /* Custom font for high scores / critical values if needed */
-      @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
       .font-press-start {
         font-family: 'Press Start 2P', cursive;
       }
@@ -34,6 +34,6 @@
 </head>
   <body>
     <div id="root"></div>
-    <script type="module" src="./dist/index.js"></script>
+    <script type="module" src="./index.tsx"></script>
   </body>
 </html>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig, loadEnv } from 'vite';
 export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
+      base: './',
       define: {
         'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)


### PR DESCRIPTION
## Summary
- support relative paths in Vite builds
- adjust import order in `index.html`
- load the TypeScript entry instead of precompiled JS

## Testing
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_6845a979767c832e8efa0a5e1245c4fe