### PR TITLE
Fix Tailwind CDN reference

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -6,7 +6,7 @@
     <base href="./" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tile Merge Saga</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
       body { font-family: 'Inter', sans-serif; background-color: #1f2937; color: #f3f4f6; }

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <base href="./" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Tile Merge Saga</title>
-    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@3.4.4/dist/tailwind.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
       body { font-family: 'Inter', sans-serif; background-color: #1f2937; color: #f3f4f6; }


### PR DESCRIPTION
## Summary
- use the official Tailwind CDN script

## Testing
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_6845c309ef2c832ea282115ba969dbe3