### PR TITLE
Enhance mobile layout and tile animations

### DIFF
--- a/components/GameOverModal.tsx
+++ b/components/GameOverModal.tsx
@@ -13,8 +13,8 @@ const GameOverModal: React.FC<GameOverModalProps> = ({ reason, score, gameStats,
   if (!reason) return null;
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4">
-      <div className="bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl text-center w-full max-w-md transform transition-all scale-100 opacity-100">
+    <div className="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4 fade-in">
+      <div className="bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl text-center w-full max-w-md transform transition-all scale-100 opacity-100 hud-glass">
         <h2 className="text-3xl font-bold text-red-500 mb-3 font-press-start">Game Over!</h2>
         <p className="text-slate-300 text-lg mb-6">{reason}</p>
         

--- a/components/GridDisplay.tsx
+++ b/components/GridDisplay.tsx
@@ -22,8 +22,8 @@ const GridDisplay: React.FC<GridDisplayProps> = ({ grid, enemies, selectedPath, 
   };
   
   return (
-    <div 
-      className="grid gap-1 p-2 bg-slate-700 rounded-lg shadow-xl"
+    <div
+      className="grid gap-1 sm:gap-2 p-2 sm:p-4 bg-slate-700 rounded-lg shadow-xl"
       style={{
         gridTemplateRows: `repeat(${grid.length}, minmax(0, 1fr))`,
         gridTemplateColumns: `repeat(${grid[0]?.length || 0}, minmax(0, 1fr))`,

--- a/components/HudDisplay.tsx
+++ b/components/HudDisplay.tsx
@@ -17,9 +17,9 @@ interface HudDisplayProps {
 }
 
 const StatItem: React.FC<{ label: string; value: string | number; className?: string }> = ({ label, value, className }) => (
-  <div className={`p-3 bg-slate-700 rounded-lg shadow text-center ${className}`}>
-    <div className="text-xs text-sky-300 uppercase tracking-wider">{label}</div>
-    <div className="text-2xl font-bold text-white">{value}</div>
+  <div className={`p-2 sm:p-3 bg-slate-700 rounded-lg shadow text-center ${className}`}>
+    <div className="text-xs sm:text-sm text-sky-300 uppercase tracking-wider">{label}</div>
+    <div className="text-xl sm:text-2xl font-bold text-white">{value}</div>
   </div>
 );
 
@@ -32,7 +32,7 @@ const HudDisplay: React.FC<HudDisplayProps> = ({
                              activePowerUpMode === ActivePowerUpMode.TELEPORT_SELECT_2;
 
   return (
-    <div className="w-full md:w-96 p-4 space-y-4 bg-slate-800 rounded-lg shadow-2xl text-slate-100">
+    <div className="w-full md:w-96 p-3 sm:p-4 space-y-4 bg-slate-800 rounded-lg shadow-2xl text-slate-100 hud-glass fade-in">
       <div className="grid grid-cols-3 gap-2">
         <StatItem label="Score" value={score} />
         <StatItem label="Energy" value={energy} className={energy <= 5 ? 'text-red-400' : energy <=10 ? 'text-yellow-400' : 'text-green-400'}/>

--- a/components/TileDisplay.tsx
+++ b/components/TileDisplay.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { Tile, Position, Enemy } from '../types';
 import { getTileColors } from '../utils/theme';
 import { ENEMY_TARGET_R, ENEMY_TARGET_C } from '../constants';
@@ -15,6 +15,17 @@ interface TileDisplayProps {
 }
 
 const TileDisplay: React.FC<TileDisplayProps> = ({ tile, position, enemyOnTile, isSelected, isPathEnd, isTeleportTarget, onInteraction }) => {
+  const tileRef = useRef<HTMLDivElement>(null);
+  const prevValueRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (tileRef.current && tile && prevValueRef.current !== null && prevValueRef.current !== tile.value) {
+      tileRef.current.classList.add('tile-merge-flash');
+      const t = setTimeout(() => tileRef.current?.classList.remove('tile-merge-flash'), 350);
+      return () => clearTimeout(t);
+    }
+    prevValueRef.current = tile?.value ?? null;
+  }, [tile?.value]);
   const handleMouseDown = () => onInteraction(position.r, position.c, 'down');
   const handleMouseEnter = () => onInteraction(position.r, position.c, 'enter');
   // onMouseUp is typically handled globally in the parent component (GridDisplay or App)
@@ -29,7 +40,8 @@ const TileDisplay: React.FC<TileDisplayProps> = ({ tile, position, enemyOnTile, 
 
   return (
     <div
-      className={`w-full aspect-square ${tileClasses} ${isTeleportTarget ? 'ring-4 ring-green-400 animate-pulse' : ''} ${isCenterCell && !enemyOnTile ? 'bg-opacity-50 border-dashed border-sky-400' : ''}`}
+      ref={tileRef}
+      className={`w-full aspect-square tile-appear ${tileClasses} ${isTeleportTarget ? 'ring-4 ring-green-400 animate-pulse' : ''} ${isCenterCell && !enemyOnTile ? 'bg-opacity-50 border-dashed border-sky-400' : ''} ${isPathEnd ? 'tile-wiggle' : ''}`}
       onMouseDown={handleMouseDown}
       onMouseEnter={handleMouseEnter}
       role="button"
@@ -45,7 +57,7 @@ const TileDisplay: React.FC<TileDisplayProps> = ({ tile, position, enemyOnTile, 
         </div>
       )}
       {tile && !enemyOnTile && (
-         <span className={`tile-value-display ${tile.value >= 1000 ? 'text-sm' : tile.value >=100 ? 'text-base' : 'text-xl' }`}>
+         <span className={`tile-value-display ${tile.value >= 1000 ? 'text-xl md:text-2xl' : tile.value >=100 ? 'text-2xl md:text-3xl' : 'text-3xl md:text-4xl' }`}>
             {displayValue}
          </span>
       )}

--- a/dist/components/GameOverModal.js
+++ b/dist/components/GameOverModal.js
@@ -2,8 +2,8 @@ import React from 'react';
 const GameOverModal = ({ reason, score, gameStats, onRestart }) => {
     if (!reason)
         return null;
-    return (React.createElement("div", { className: "fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4" },
-        React.createElement("div", { className: "bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl text-center w-full max-w-md transform transition-all scale-100 opacity-100" },
+    return (React.createElement("div", { className: "fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4 fade-in" },
+        React.createElement("div", { className: "bg-slate-800 p-6 md:p-8 rounded-xl shadow-2xl text-center w-full max-w-md transform transition-all scale-100 opacity-100 hud-glass" },
             React.createElement("h2", { className: "text-3xl font-bold text-red-500 mb-3 font-press-start" }, "Game Over!"),
             React.createElement("p", { className: "text-slate-300 text-lg mb-6" }, reason),
             React.createElement("div", { className: "mb-6 p-4 bg-slate-700 rounded-lg" },

--- a/dist/components/GridDisplay.js
+++ b/dist/components/GridDisplay.js
@@ -7,7 +7,7 @@ const GridDisplay = ({ grid, enemies, selectedPath, activePowerUpMode, teleportF
         // The main logic for 'up' interaction type is passed via onTileInteraction and typically handled in useGameLogic.
         onMouseUpGlobal();
     };
-    return (React.createElement("div", { className: "grid gap-1 p-2 bg-slate-700 rounded-lg shadow-xl", style: {
+    return (React.createElement("div", { className: "grid gap-1 sm:gap-2 p-2 sm:p-4 bg-slate-700 rounded-lg shadow-xl", style: {
             gridTemplateRows: `repeat(${grid.length}, minmax(0, 1fr))`,
             gridTemplateColumns: `repeat(${grid[0]?.length || 0}, minmax(0, 1fr))`,
         }, onMouseUp: handleMouseUp, onMouseLeave: handleMouseUp }, grid.map((row, r) => row.map((tile, c) => {

--- a/dist/components/HudDisplay.js
+++ b/dist/components/HudDisplay.js
@@ -1,14 +1,14 @@
 import React from 'react';
 import { ActivePowerUpMode } from '../types.js';
 import { getPowerUpIcon, getPowerUpTooltip, PowerUpColors } from '../utils/theme.js';
-const StatItem = ({ label, value, className }) => (React.createElement("div", { className: `p-3 bg-slate-700 rounded-lg shadow text-center ${className}` },
-    React.createElement("div", { className: "text-xs text-sky-300 uppercase tracking-wider" }, label),
-    React.createElement("div", { className: "text-2xl font-bold text-white" }, value)));
+const StatItem = ({ label, value, className }) => (React.createElement("div", { className: `p-2 sm:p-3 bg-slate-700 rounded-lg shadow text-center ${className}` },
+    React.createElement("div", { className: "text-xs sm:text-sm text-sky-300 uppercase tracking-wider" }, label),
+    React.createElement("div", { className: "text-xl sm:text-2xl font-bold text-white" }, value)));
 const HudDisplay = ({ score, energy, turn, mission, availablePowerUps, gameStats, isDoublerActive, activePowerUpMode, onActivatePowerUp, onCancelPowerUp }) => {
     const isTargetingPowerUp = activePowerUpMode === ActivePowerUpMode.BOMB_TARGETING ||
         activePowerUpMode === ActivePowerUpMode.TELEPORT_SELECT_1 ||
         activePowerUpMode === ActivePowerUpMode.TELEPORT_SELECT_2;
-    return (React.createElement("div", { className: "w-full md:w-96 p-4 space-y-4 bg-slate-800 rounded-lg shadow-2xl text-slate-100" },
+    return (React.createElement("div", { className: "w-full md:w-96 p-3 sm:p-4 space-y-4 bg-slate-800 rounded-lg shadow-2xl text-slate-100 hud-glass fade-in" },
         React.createElement("div", { className: "grid grid-cols-3 gap-2" },
             React.createElement(StatItem, { label: "Score", value: score }),
             React.createElement(StatItem, { label: "Energy", value: energy, className: energy <= 5 ? 'text-red-400' : energy <= 10 ? 'text-yellow-400' : 'text-green-400' }),

--- a/dist/components/TileDisplay.js
+++ b/dist/components/TileDisplay.js
@@ -1,7 +1,17 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import { getTileColors } from '../utils/theme.js';
 import { ENEMY_TARGET_R, ENEMY_TARGET_C } from '../constants.js';
 const TileDisplay = ({ tile, position, enemyOnTile, isSelected, isPathEnd, isTeleportTarget, onInteraction }) => {
+    const tileRef = useRef(null);
+    const prevValueRef = useRef(null);
+    useEffect(() => {
+        if (tileRef.current && tile && prevValueRef.current !== null && prevValueRef.current !== tile.value) {
+            tileRef.current.classList.add('tile-merge-flash');
+            const t = setTimeout(() => tileRef.current?.classList.remove('tile-merge-flash'), 350);
+            return () => clearTimeout(t);
+        }
+        prevValueRef.current = tile?.value ?? null;
+    }, [tile?.value]);
     const handleMouseDown = () => onInteraction(position.r, position.c, 'down');
     const handleMouseEnter = () => onInteraction(position.r, position.c, 'enter');
     // onMouseUp is typically handled globally in the parent component (GridDisplay or App)
@@ -10,11 +20,11 @@ const TileDisplay = ({ tile, position, enemyOnTile, isSelected, isPathEnd, isTel
     const tileClasses = getTileColors(tileValue ?? 0, cooldown, !!enemyOnTile, isSelected, isPathEnd);
     const displayValue = tileValue !== null && tileValue !== undefined ? tileValue : '';
     const isCenterCell = position.r === ENEMY_TARGET_R && position.c === ENEMY_TARGET_C;
-    return (React.createElement("div", { className: `w-full aspect-square ${tileClasses} ${isTeleportTarget ? 'ring-4 ring-green-400 animate-pulse' : ''} ${isCenterCell && !enemyOnTile ? 'bg-opacity-50 border-dashed border-sky-400' : ''}`, onMouseDown: handleMouseDown, onMouseEnter: handleMouseEnter, role: "button", "aria-label": `Tile at ${position.r}, ${position.c} with value ${displayValue}`, tabIndex: 0 },
+    return (React.createElement("div", { ref: tileRef, className: `w-full aspect-square tile-appear ${tileClasses} ${isTeleportTarget ? 'ring-4 ring-green-400 animate-pulse' : ''} ${isCenterCell && !enemyOnTile ? 'bg-opacity-50 border-dashed border-sky-400' : ''} ${isPathEnd ? 'tile-wiggle' : ''}`, onMouseDown: handleMouseDown, onMouseEnter: handleMouseEnter, role: "button", "aria-label": `Tile at ${position.r}, ${position.c} with value ${displayValue}`, tabIndex: 0 },
         enemyOnTile && (React.createElement("span", { className: "absolute text-3xl animate-bounce z-10", role: "img", "aria-label": "Enemy" }, "\uD83D\uDC80")),
         cooldown > 0 && !enemyOnTile && (React.createElement("div", { className: "absolute inset-0 bg-black bg-opacity-50 flex items-center justify-center rounded-lg z-20" },
             React.createElement("span", { className: "text-white text-xl font-bold font-mono" }, cooldown))),
-        tile && !enemyOnTile && (React.createElement("span", { className: `tile-value-display ${tile.value >= 1000 ? 'text-sm' : tile.value >= 100 ? 'text-base' : 'text-xl'}` }, displayValue)),
+        tile && !enemyOnTile && (React.createElement("span", { className: `tile-value-display ${tile.value >= 1000 ? 'text-xl md:text-2xl' : tile.value >= 100 ? 'text-2xl md:text-3xl' : 'text-3xl md:text-4xl'}` }, displayValue)),
         isCenterCell && !tile && !enemyOnTile && (React.createElement("span", { className: "text-sky-300 text-3xl font-bold opacity-50" }, "\uD83C\uDFAF"))));
 };
 export default TileDisplay;

--- a/dist/utils/theme.js
+++ b/dist/utils/theme.js
@@ -65,7 +65,7 @@ export const getTileColors = (value, cooldown, isEnemy, isSelected, isPathEnd) =
                     baseColors = 'bg-black border-gray-700 text-yellow-300 font-press-start';
         }
     }
-    let effects = 'transition-all duration-150 ease-in-out transform hover:scale-105';
+    let effects = 'transition-all duration-200 ease-out transform hover:scale-105 active:scale-95';
     if (isSelected) {
         effects += ' ring-4 ring-yellow-400 scale-110 z-10';
         if (isPathEnd)

--- a/index.css
+++ b/index.css
@@ -3,6 +3,56 @@
 /* Example body style mirroring index.html */
 body {
   font-family: 'Inter', sans-serif;
-  background-color: #1f2937; /* slate-800 */
   color: #f3f4f6; /* slate-100 */
+  background: radial-gradient(circle at top left, #1f2937, #111827);
+  min-height: 100vh;
+  background-attachment: fixed;
+}
+.tile-value-display {
+  font-weight: 800;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.25);
+}
+
+@keyframes tile-pop {
+  0% { transform: scale(0.6); opacity: 0; }
+  60% { transform: scale(1.2); opacity: 1; }
+  100% { transform: scale(1); }
+}
+
+@keyframes tile-merge-flash {
+  0% { box-shadow: 0 0 0 0 rgba(255,255,255,0.7); }
+  70% { box-shadow: 0 0 20px 10px rgba(255,255,255,0); transform: scale(1.2); }
+  100% { box-shadow: 0 0 0 0 rgba(255,255,255,0); transform: scale(1); }
+}
+
+@keyframes tile-wiggle {
+  0%,100% { transform: rotate(0); }
+  25% { transform: rotate(2deg); }
+  75% { transform: rotate(-2deg); }
+}
+
+.tile-appear {
+  animation: tile-pop 0.3s ease-out;
+}
+
+.tile-merge-flash {
+  animation: tile-merge-flash 0.35s ease-out;
+}
+
+.tile-wiggle {
+  animation: tile-wiggle 0.5s ease-in-out infinite;
+}
+
+.hud-glass {
+  background: rgba(30,41,59,0.8); /* slate-800 with opacity */
+  backdrop-filter: blur(10px);
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: scale(0.9); }
+  to { opacity: 1; transform: scale(1); }
+}
+
+.fade-in {
+  animation: fade-in 0.3s ease-out;
 }

--- a/utils/theme.ts
+++ b/utils/theme.ts
@@ -28,7 +28,7 @@ export const getTileColors = (value: number, cooldown: number, isEnemy?: boolean
     }
   }
 
-  let effects = 'transition-all duration-150 ease-in-out transform hover:scale-105';
+  let effects = 'transition-all duration-200 ease-out transform hover:scale-105 active:scale-95';
   if (isSelected) {
     effects += ' ring-4 ring-yellow-400 scale-110 z-10';
     if(isPathEnd) effects += ' ring-sky-300';


### PR DESCRIPTION
## Summary
- add AAA-style animations for tiles
- make HUD glassy with fade-in
- apply wiggle and flash effects when tiles merge
- give modal fade-in and glass background
- update dist/ JS

## Testing
- `node compile_ts.cjs`


------
https://chatgpt.com/codex/tasks/task_e_6845e0909030832e9307573e52dd51f5